### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,9 @@ work with TI and get various base source code to begint the process. After that 
 done as patches on top  of the original files. Any changes that are planned to support newer features and/or
 platforms are done as patch files.
 
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+
 ## Pull Requests
 We actively welcome your pull requests.
 


### PR DESCRIPTION
In the past there was not info and support to add these docs to all Facebook Open Source projects. We can fix it. :)

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve [the BridgeIC community profile](https://github.com/facebook/BridgeIC/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch -
<img width="1490" alt="screen shot 2018-01-14 at 2 53 23 pm" src="https://user-images.githubusercontent.com/1114467/34921752-12d963b0-f93b-11e7-911f-e19efb906fdd.png">
<img width="1496" alt="screen shot 2018-01-14 at 2 53 35 pm" src="https://user-images.githubusercontent.com/1114467/34921753-130d585a-f93b-11e7-9311-8ea49ceaf4ce.png">


**issue:**
internal task t23481323